### PR TITLE
fix: Instrument window bug

### DIFF
--- a/src/components/Instrument.tsx
+++ b/src/components/Instrument.tsx
@@ -54,10 +54,10 @@ const InstrumentFrame: React.FC<InstrumentFrameProps> = memo(forwardRef(
                 )}
             />
         );
-    }),
-);
+    },
+));
 
-export const Instrument: React.FC<Element> = ({ uuid, name, element, x, y, width, height }) => {
+export const Instrument: React.FC<Element> = ({ uuid, name, element, x, y, width, height, onMouseEnter, onMouseLeave }) => {
     const iframeRef = useRef<HTMLIFrameElement>(null);
     const containerRef = useRef<HTMLDivElement>(null);
 
@@ -122,7 +122,7 @@ export const Instrument: React.FC<Element> = ({ uuid, name, element, x, y, width
                 element={{ uuid, name, element, x, y, width, height }}
                 x={e.clientX}
                 y={e.clientY}
-            />
+            />,
         ))
     ), [dispatch]);
 
@@ -152,6 +152,8 @@ export const Instrument: React.FC<Element> = ({ uuid, name, element, x, y, width
                 width,
                 height,
             }}
+            onMouseEnter={onMouseEnter}
+            onMouseLeave={onMouseLeave}
         >
             <div className="absolute bottom-full w-full box-content border-2 border-b-0 border-silver-800 bg-silver-800 rounded-t-xl">
                 <div className="absolute -top-0.5 w-full flex justify-center">

--- a/src/pages/Workspace.tsx
+++ b/src/pages/Workspace.tsx
@@ -83,11 +83,13 @@ const CanvasLayer: React.FC = () => {
     const project = useWorkspaceSelector((state: WorkspaceState) => state.project.active);
     const dispatch = useWorkspaceDispatch();
 
+    const [transformDisabled, setTransformDisabled] = useState(false);
+
     const dndContext = useDndContext();
 
     return (
         <TransformWrapper
-            disabled={dndContext.active !== null}
+            disabled={transformDisabled}
             centerOnInit
             minScale={0.25}
             initialScale={0.5}
@@ -112,7 +114,11 @@ const CanvasLayer: React.FC = () => {
                     }}
                 >
                     {project?.config.elements?.map((props) => (
-                        <Instrument {...props} />
+                        <Instrument
+                            {...props}
+                            onMouseEnter={() => setTransformDisabled(true)}
+                            onMouseLeave={() => setTransformDisabled(false)}
+                        />
                     ))}
                 </div>
             </TransformComponent>

--- a/src/pages/Workspace.tsx
+++ b/src/pages/Workspace.tsx
@@ -85,9 +85,11 @@ const CanvasLayer: React.FC = () => {
 
     const [transformDisabled, setTransformDisabled] = useState(false);
 
+    const dndContext = useDndContext();
+
     return (
         <TransformWrapper
-            disabled={transformDisabled}
+            disabled={transformDisabled || dndContext.active !== null}
             centerOnInit
             minScale={0.25}
             initialScale={0.5}

--- a/src/pages/Workspace.tsx
+++ b/src/pages/Workspace.tsx
@@ -85,8 +85,6 @@ const CanvasLayer: React.FC = () => {
 
     const [transformDisabled, setTransformDisabled] = useState(false);
 
-    const dndContext = useDndContext();
-
     return (
         <TransformWrapper
             disabled={transformDisabled}

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,8 +8,8 @@ export interface Element {
     height: number;
     x: number;
     y: number;
-    onMouseEnter: () => void;
-    onMouseLeave: () => void;
+    onMouseEnter?: () => void;
+    onMouseLeave?: () => void;
 }
 
 export interface AceConfig {

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,6 +8,8 @@ export interface Element {
     height: number;
     x: number;
     y: number;
+    onMouseEnter: () => void;
+    onMouseLeave: () => void;
 }
 
 export interface AceConfig {


### PR DESCRIPTION
closes #11 

Previously when interacting with the instrument frame the TransformWrapper would randomly jump to to a different locations on the Canvas. This introduces a shared state between the Canvas & Instrument components such that the transform wrapper is disabled when the mouse is within an instrument frame. 